### PR TITLE
Updated elfos_final.inc and caOS.bat to generate Elf/OS programs with…

### DIFF
--- a/bat/caOS.bat
+++ b/bat/caOS.bat
@@ -3,9 +3,9 @@
 @c:\lcc42\bin\lcc.exe "-target=xr18CX" "-Wf-g,;" "-Wf-elfos" -S %2 %3 %4 %5 %6 %1.c 
 @IF ERRORLEVEL 1 GOTO quit
 @c:\lcc42\bin\copt c:\lcc42\include\lcc1806.opt -I %1.asm -O %1.oasm
-@c:\lcc42\bin\asw -cpu 1802 -quiet -D LCCELFOS=1 -D CODELOC=0x2000 -D STACKLOC=0x7FFF  -D LCCNOIO -P -x -i c:\lcc42\include -L %1.oasm
+@c:\lcc42\bin\asw -cpu 1802 -quiet -D LCCELFOS=1 -D CODELOC=0x2010 -D STACKLOC=0x7FFF  -D LCCNOIO -P -x -i c:\lcc42\include -L %1.oasm
 @c:\lcc42\bin\p2hex -r $-$ %1 %1 
 @c:\lcc42\bin\p2bin -r $-$ %1 %1
 @:quit
 
-@rem c:\lcc42\bin\lcc.exe "-target=xr18CX" "-Wf-g,;"  "-Wf-volatile"  "-Wa -D LCCELFOS" "-Wa -D CODELOC=0x2000"  "-Wa -D STACKLOC=0x7Fff" %2 %3 %4 %5 %6 %1.c 
+@rem c:\lcc42\bin\lcc.exe "-target=xr18CX" "-Wf-g,;"  "-Wf-volatile"  "-Wa -D LCCELFOS" "-Wa -D CODELOC=0x2010"  "-Wa -D STACKLOC=0x7Fff" %2 %3 %4 %5 %6 %1.c 

--- a/include/devkit/system/elfos_final.inc
+++ b/include/devkit/system/elfos_final.inc
@@ -1,12 +1,25 @@
 ;elfos_final.inc builds the 6 byte elfos header
 ;Thanks to Marcel Tongren for the code pattern in his basic_final.inc
 ;21-07-10 First version
+;22-01-28 grw - updated to include build information (CODELOC changes to 0x2010) 
     
  IFDEF LCCELFOS
-$$EOP:		;end of module
+month set SUBSTR(DATE,0,STRSTR(DATE,"/"))
+year set SUBSTR(DATE,STRLEN(DATE)-4,4)
+month set SUBSTR(DATE,0,STRSTR(DATE,"/"))
+chunk set SUBSTR(DATE,STRSTR(DATE,"/")+1,3)
+day set SUBSTR(chunk,0,STRSTR(chunk,"/"))  
 
+$$EOP:		;end of module
     org 0x1FFA	;org back to build elfos header
     dw 0x2000	;module begin address
     dw $$EOP-0x2000
     dw 0x2000
+    br $$start  ;branch past build info to start of program
+    db val(month)+0x80
+    db val(day)
+    dw val(year)
+    dw 1
+    db "LCC1802",0
+$$start:     
  ENDIF


### PR DESCRIPTION
Updated code in elfos_final.inc to add the current date information, build number and "LCC1802" identification string.  The change includes the initial branch statement to branch over the build information to the new program code location (CODELOC) which is now immediately after the build information at 0x2010.

The batch file caOS.bat to update CODELOC with the new value of 0x2010.

This code has been tested with helloworld.c which works as expected.  Running the Elf/OS version command against this binary, with the command "ver helloworld", yields the expected string "1/29/2022 Build: 1  LCC1802" with the correct date string.
